### PR TITLE
Fix project filtering layout for logo and layout tabs

### DIFF
--- a/style.css
+++ b/style.css
@@ -228,9 +228,7 @@ body {
 
 /* Hide state for filtering */
 .project-card.hide {
-    opacity: 0;
-    transform: translateY(20px);
-    pointer-events: none;
+    display: none;
 }
 
 /* Contact section */


### PR DESCRIPTION
## Summary
- Ensure filtered project cards use `display:none` so category sections like Loga and Layouty display images from the top

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688d05f9a964832fa598a83613160d99