### PR TITLE
Add dynamic pricing table

### DIFF
--- a/index.html
+++ b/index.html
@@ -137,6 +137,23 @@
         </div>
     </section>
 
+    <!-- Pricing section -->
+    <section id="pricing" class="pricing">
+        <div class="container">
+            <h2>Cennik</h2>
+            <table id="pricing-table">
+                <thead>
+                    <tr>
+                        <th>Plan</th>
+                        <th>Cena</th>
+                        <th>Cytat</th>
+                    </tr>
+                </thead>
+                <tbody></tbody>
+            </table>
+        </div>
+    </section>
+
     <!-- Contact section -->
     <section id="contact" class="contact">
         <div class="container">
@@ -156,6 +173,6 @@
         </div>
     </footer>
 
-    <script src="script.js"></script>
+    <script type="module" src="script.js"></script>
 </body>
 </html>

--- a/pricing-data.js
+++ b/pricing-data.js
@@ -1,0 +1,17 @@
+export const pricingData = [
+    {
+        plan: 'Podstawowy',
+        price: '100 zł',
+        quote: '„Idealny dla startujących projektów.”'
+    },
+    {
+        plan: 'Standard',
+        price: '200 zł',
+        quote: '„Najlepszy stosunek jakości do ceny.”'
+    },
+    {
+        plan: 'Premium',
+        price: '400 zł',
+        quote: '„Pełnia możliwości i wsparcia.”'
+    }
+];

--- a/pricing.md
+++ b/pricing.md
@@ -1,0 +1,5 @@
+| Plan       | Cena   | Cytat                                   |
+|------------|--------|-----------------------------------------|
+| Podstawowy | 100 zł | "Idealny dla startujących projektów."   |
+| Standard   | 200 zł | "Najlepszy stosunek jakości do ceny."  |
+| Premium    | 400 zł | "Pełnia możliwości i wsparcia."        |

--- a/script.js
+++ b/script.js
@@ -1,4 +1,6 @@
-// Basic interactions: set current year, handle contact form submission and category filtering
+import { pricingData } from './pricing-data.js';
+
+// Basic interactions: set current year, handle contact form submission, category filtering and pricing table
 document.addEventListener('DOMContentLoaded', () => {
     // Set current year in footer
     const yearSpan = document.getElementById('year');
@@ -36,4 +38,18 @@ document.addEventListener('DOMContentLoaded', () => {
             });
         });
     });
+
+    // Populate pricing table
+    const pricingTableBody = document.querySelector('#pricing-table tbody');
+    if (pricingTableBody) {
+        pricingData.forEach(item => {
+            const row = document.createElement('tr');
+            [item.plan, item.price, item.quote].forEach(text => {
+                const td = document.createElement('td');
+                td.textContent = text;
+                row.appendChild(td);
+            });
+            pricingTableBody.appendChild(row);
+        });
+    }
 });


### PR DESCRIPTION
## Summary
- create pricing data and reference markdown table
- import pricing data and dynamically build pricing table
- expose pricing table in a new section and load script as a module

## Testing
- `node --check script.js`
- `node -e "import('./pricing-data.js').then(m=>console.log(m.pricingData))"`


------
https://chatgpt.com/codex/tasks/task_e_688de41d5c68832f883a63facbe04533