### PR TITLE
Add pricing section and navigation link

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,8 +15,9 @@
                     <ul>
                         <li><a href="#about">O mnie</a></li>
                         <li><a href="#skills">Umiejętności</a></li>
-                        <li><a href="#projects">Realizacje</a></li>
-                        <li><a href="#contact">Kontakt</a></li>
+                         <li><a href="#projects">Realizacje</a></li>
+                         <li><a href="#cennik">Cennik</a></li>
+                         <li><a href="#contact">Kontakt</a></li>
                     </ul>
                 </nav>
             </div>
@@ -29,8 +30,9 @@
             <div class="hero-text">
                 <h1>Cześć, jestem Bartłomiej Konkel</h1>
                 <p>Tworzę wizualizacje, aranżacje wnętrz, loga i layouty stron, a także implementuję je w kodzie – tak, aby Twoje projekty zachwycały i inspirowały.</p>
-                <a href="#projects" class="btn-primary">Zobacz moje realizacje</a>
-            </div>
+                 <a href="#projects" class="btn-primary">Zobacz moje realizacje</a>
+                 <a href="#cennik" class="btn-primary">Sprawdź cennik</a>
+             </div>
             <div class="hero-image">
                 <video src="hero_logo_video.mp4" autoplay loop muted playsinline class="hero-logo-video"></video>
             </div>
@@ -132,6 +134,30 @@
                     <img src="logo_100.png" alt="Szablon strony" class="project-image">
                     <h3>Szablon strony</h3>
                     <p>Przykładowy szablon strony internetowej – wkrótce więcej!</p>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <!-- Pricing section -->
+    <section id="cennik" class="cennik">
+        <div class="container">
+            <h2>Cennik tworzenia stron internetowych, logo i grafiki – 2025</h2>
+            <div class="pricing-grid">
+                <div class="pricing-card">
+                    <h3>Projekty stron</h3>
+                    <p>Kompletne projekty responsywnych stron WWW.</p>
+                    <p class="price">od 1500 zł</p>
+                </div>
+                <div class="pricing-card">
+                    <h3>Projekty logo</h3>
+                    <p>Indywidualne logotypy dopasowane do marki.</p>
+                    <p class="price">od 500 zł</p>
+                </div>
+                <div class="pricing-card">
+                    <h3>Grafiki promocyjne</h3>
+                    <p>Banery, plakaty i materiały reklamowe.</p>
+                    <p class="price">od 300 zł</p>
                 </div>
             </div>
         </div>

--- a/style.css
+++ b/style.css
@@ -226,6 +226,47 @@ body {
     font-size: 0.95rem;
 }
 
+/* Pricing section */
+#cennik {
+    padding: 60px 0;
+    background-color: var(--secondary-color);
+}
+
+#cennik h2 {
+    font-size: 2rem;
+    margin-bottom: 20px;
+    color: var(--primary-color);
+}
+
+#cennik .pricing-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+    gap: 30px;
+}
+
+#cennik .pricing-card {
+    background-color: var(--bg-color);
+    padding: 20px;
+    border: 1px solid var(--primary-color);
+    border-radius: 10px;
+    text-align: center;
+    box-shadow: 0 0 15px rgba(0,255,128,0.2);
+}
+
+#cennik .pricing-card h3 {
+    margin-bottom: 10px;
+    color: var(--primary-color);
+}
+
+#cennik .pricing-card p {
+    margin-bottom: 5px;
+}
+
+#cennik .price {
+    font-weight: bold;
+    color: var(--primary-color);
+}
+
 /* Hide state for filtering */
 .project-card.hide {
     display: none;


### PR DESCRIPTION
## Summary
- add new "Cennik" link to navigation and hero call-to-action button
- introduce dedicated pricing section with 2025 heading
- populate pricing section with sample offerings and themed cards

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688dd8e8982c832f86d943f2a722f006