### PR TITLE
Add animated price comparison chart

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Portfolio Bartłomieja Konkla</title>
     <link rel="stylesheet" href="style.css">
+    <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js"></script>
 </head>
 <body>
     <header class="site-header">
@@ -133,6 +134,16 @@
                     <h3>Szablon strony</h3>
                     <p>Przykładowy szablon strony internetowej – wkrótce więcej!</p>
                 </div>
+            </div>
+        </div>
+    </section>
+
+    <!-- Pricing comparison chart -->
+    <section id="pricing" class="pricing">
+        <div class="container">
+            <h2>Płacisz mniej, dostajesz więcej – proste! 💸</h2>
+            <div class="chart-container">
+                <canvas id="priceChart"></canvas>
             </div>
         </div>
     </section>

--- a/script.js
+++ b/script.js
@@ -36,4 +36,59 @@ document.addEventListener('DOMContentLoaded', () => {
             });
         });
     });
+
+    // Price comparison chart with intersection-triggered animation
+    const market = [3000, 2000, 400, 150];
+    const mine = [1200, 800, 160, 60];
+    const canvas = document.getElementById('priceChart');
+    if (canvas) {
+        const ctx = canvas.getContext('2d');
+        const labels = ['Strona WWW', 'Sklep online', 'Projekt logo', 'Wizytówka'];
+        const chartData = {
+            labels,
+            datasets: [
+                {
+                    label: 'Rynek',
+                    data: [0, 0, 0, 0],
+                    backgroundColor: '#444444'
+                },
+                {
+                    label: 'Twoja cena',
+                    data: [0, 0, 0, 0],
+                    backgroundColor: '#18d4c4'
+                }
+            ]
+        };
+
+        const priceChart = new Chart(ctx, {
+            type: 'bar',
+            data: chartData,
+            options: {
+                indexAxis: 'y',
+                responsive: true,
+                animation: {
+                    duration: 1000,
+                    easing: 'easeOutQuad'
+                },
+                scales: {
+                    x: {
+                        beginAtZero: true
+                    }
+                }
+            }
+        });
+
+        const observer = new IntersectionObserver((entries, obs) => {
+            entries.forEach(entry => {
+                if (entry.isIntersecting) {
+                    priceChart.data.datasets[0].data = market;
+                    priceChart.data.datasets[1].data = mine;
+                    priceChart.update();
+                    obs.disconnect();
+                }
+            });
+        }, { threshold: 0.3 });
+
+        observer.observe(canvas.closest('section'));
+    }
 });

--- a/style.css
+++ b/style.css
@@ -231,6 +231,27 @@ body {
     display: none;
 }
 
+/* Pricing chart */
+.pricing {
+    padding: 80px 0;
+}
+
+.pricing h2 {
+    text-align: center;
+    margin-bottom: 40px;
+    color: var(--primary-color);
+}
+
+.chart-container {
+    position: relative;
+    max-width: 600px;
+    margin: 0 auto;
+    background-color: var(--secondary-color);
+    padding: 20px;
+    border-radius: 10px;
+    box-shadow: 0 0 15px rgba(0,255,128,0.2);
+}
+
 /* Contact section */
 .contact form {
     max-width: 500px;


### PR DESCRIPTION
## Summary
- load Chart.js via CDN and add pricing section with canvas to display price comparison
- style new pricing section and chart container
- render horizontal bar chart comparing market vs custom prices and animate on scroll with IntersectionObserver

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688ddcb923f8832f8c9800b075ea6a95