### PR TITLE
Add net/gross pricing toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -137,6 +137,35 @@
         </div>
     </section>
 
+    <!-- Pricing section -->
+    <section id="pricing" class="pricing">
+        <div class="container">
+            <h2>Cennik</h2>
+            <div class="tax-toggle">
+                <input type="checkbox" id="tax-toggle">
+                <label for="tax-toggle">Netto / Brutto</label>
+            </div>
+            <table id="price-table">
+                <thead>
+                    <tr>
+                        <th>Usługa</th>
+                        <th>Cena (zł)</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                        <td>Projekt logo</td>
+                        <td class="price" data-net="100">100.00</td>
+                    </tr>
+                    <tr>
+                        <td>Strona internetowa</td>
+                        <td class="price" data-net="500">500.00</td>
+                    </tr>
+                </tbody>
+            </table>
+        </div>
+    </section>
+
     <!-- Contact section -->
     <section id="contact" class="contact">
         <div class="container">

--- a/script.js
+++ b/script.js
@@ -36,4 +36,20 @@ document.addEventListener('DOMContentLoaded', () => {
             });
         });
     });
+
+    // Toggle net/gross prices
+    const taxToggle = document.getElementById('tax-toggle');
+    if (taxToggle) {
+        const priceCells = document.querySelectorAll('#price-table .price');
+        taxToggle.addEventListener('change', () => {
+            priceCells.forEach(cell => {
+                const net = parseFloat(cell.dataset.net);
+                if (taxToggle.checked) {
+                    cell.innerText = (net * 1.23).toFixed(2);
+                } else {
+                    cell.innerText = net.toFixed(2);
+                }
+            });
+        });
+    }
 });


### PR DESCRIPTION
## Summary
- add pricing table with Netto/Brutto checkbox switch
- implement JS listener to recalc prices by VAT multiplier

## Testing
- `npm test` *(fails: ENOENT could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688ddd8465e0832fa42182f112e92811