### PR TITLE
Add pricing packages and FAQ section

### DIFF
--- a/index.html
+++ b/index.html
@@ -137,6 +137,71 @@
         </div>
     </section>
 
+    <!-- Pricing section -->
+    <section id="cennik" class="cennik">
+        <div class="container">
+            <h2>Cennik</h2>
+            <table class="pricing-table">
+                <thead>
+                    <tr><th>Usługa</th><th>Cena</th></tr>
+                </thead>
+                <tbody>
+                    <tr><td>Projekt logo</td><td>od 300 zł</td></tr>
+                    <tr><td>Wizualizacja 3D</td><td>od 500 zł</td></tr>
+                </tbody>
+            </table>
+            <div class="packages">
+                <div class="package">
+                    <div class="package-inner">
+                        <div class="package-front">
+                            <h3>START</h3>
+                            <p class="price">299 zł</p>
+                        </div>
+                        <div class="package-back">
+                            <p>Podstawowy pakiet dla małych projektów.</p>
+                        </div>
+                    </div>
+                </div>
+                <div class="package">
+                    <div class="package-inner">
+                        <div class="package-front">
+                            <h3>BOOST</h3>
+                            <p class="price">599 zł</p>
+                        </div>
+                        <div class="package-back">
+                            <p>Rozszerzony pakiet z dodatkowymi funkcjami.</p>
+                        </div>
+                    </div>
+                </div>
+                <div class="package">
+                    <div class="package-inner">
+                        <div class="package-front">
+                            <h3>FULL CARE</h3>
+                            <p class="price">999 zł</p>
+                        </div>
+                        <div class="package-back">
+                            <p>Kompleksowa obsługa i wsparcie.</p>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <div class="faq">
+                <div class="faq-item">
+                    <button class="faq-question">Dlaczego tak tanio?</button>
+                    <div class="faq-answer">
+                        <p>Stawiam na długoterminową współpracę i transparentne ceny.</p>
+                    </div>
+                </div>
+                <div class="faq-item">
+                    <button class="faq-question">Jak mogę zamówić?</button>
+                    <div class="faq-answer">
+                        <p>Skontaktuj się ze mną przez formularz kontaktowy a ustalimy szczegóły.</p>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+
     <!-- Contact section -->
     <section id="contact" class="contact">
         <div class="container">

--- a/script.js
+++ b/script.js
@@ -36,4 +36,26 @@ document.addEventListener('DOMContentLoaded', () => {
             });
         });
     });
+
+    // Package flip on click (for touch devices)
+    const packages = document.querySelectorAll('.package');
+    packages.forEach(pkg => {
+        pkg.addEventListener('click', () => {
+            pkg.classList.toggle('flipped');
+        });
+    });
+
+    // FAQ accordion
+    const faqQuestions = document.querySelectorAll('.faq-question');
+    faqQuestions.forEach(question => {
+        question.addEventListener('click', () => {
+            question.classList.toggle('active');
+            const answer = question.nextElementSibling;
+            if (answer.style.maxHeight) {
+                answer.style.maxHeight = null;
+            } else {
+                answer.style.maxHeight = answer.scrollHeight + 'px';
+            }
+        });
+    });
 });

--- a/style.css
+++ b/style.css
@@ -271,6 +271,133 @@ body {
     font-size: 0.9rem;
 }
 
+/* Pricing table */
+.cennik {
+    padding: 60px 0;
+}
+
+.pricing-table {
+    width: 100%;
+    border-collapse: collapse;
+    margin-bottom: 40px;
+}
+
+.pricing-table th,
+.pricing-table td {
+    border: 1px solid var(--primary-color);
+    padding: 10px;
+    text-align: left;
+}
+
+.pricing-table th {
+    background-color: var(--secondary-color);
+    color: var(--primary-color);
+}
+
+/* Packages grid */
+.packages {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    gap: 20px;
+    margin-bottom: 40px;
+}
+
+.package {
+    perspective: 1000px;
+}
+
+.package-inner {
+    position: relative;
+    width: 100%;
+    height: 200px;
+    transition: transform 0.6s;
+    transform-style: preserve-3d;
+}
+
+.package:hover .package-inner,
+.package.flipped .package-inner {
+    transform: rotateY(180deg);
+}
+
+.package-front,
+.package-back {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    backface-visibility: hidden;
+    border: 1px solid var(--primary-color);
+    border-radius: 10px;
+    padding: 20px;
+    background-color: var(--secondary-color);
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+}
+
+.package-back {
+    transform: rotateY(180deg);
+}
+
+.package-front .price {
+    margin-top: 10px;
+    font-size: 1.5rem;
+    color: var(--primary-color);
+}
+
+/* FAQ accordion */
+.faq {
+    margin-top: 40px;
+}
+
+.faq-item {
+    margin-bottom: 10px;
+    border: 1px solid var(--primary-color);
+    border-radius: 5px;
+    overflow: hidden;
+}
+
+.faq-question {
+    width: 100%;
+    background: var(--secondary-color);
+    color: var(--primary-color);
+    border: none;
+    padding: 15px;
+    text-align: left;
+    font-size: 1rem;
+    cursor: pointer;
+    position: relative;
+}
+
+.faq-question::after {
+    content: '+';
+    position: absolute;
+    right: 15px;
+    transition: transform 0.3s;
+}
+
+.faq-question.active {
+    background-color: var(--primary-color);
+    color: #00130d;
+}
+
+.faq-question.active::after {
+    transform: rotate(45deg);
+}
+
+.faq-answer {
+    max-height: 0;
+    overflow: hidden;
+    background-color: var(--secondary-color);
+    transition: max-height 0.3s ease;
+}
+
+.faq-answer p {
+    padding: 15px;
+}
+
 /* Responsive */
 @media (max-width: 768px) {
     .navigation ul {


### PR DESCRIPTION
## Summary
- add pricing cards for START, BOOST, and FULL CARE plans with flip animation
- implement FAQ accordion under the pricing cards
- style pricing grid, flip effect, and FAQ

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688dde95b414832faf0840aaf702f5b9