### PR TITLE
Add aftercare section with modal

### DIFF
--- a/index.html
+++ b/index.html
@@ -137,6 +137,52 @@
         </div>
     </section>
 
+    <!-- Aftercare section -->
+    <section id="aftercare" class="aftercare">
+        <div class="container">
+            <h2>Opieka po realizacji</h2>
+            <table class="aftercare-table">
+                <thead>
+                    <tr>
+                        <th>Plan</th>
+                        <th>Opis</th>
+                        <th>Cena</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                        <td>Light</td>
+                        <td>Podstawowa opieka po wdrożeniu projektu.</td>
+                        <td>60 zł</td>
+                    </tr>
+                    <tr>
+                        <td>Pro</td>
+                        <td>Rozszerzona opieka i wsparcie techniczne.</td>
+                        <td>110 zł</td>
+                    </tr>
+                    <tr>
+                        <td>VIP</td>
+                        <td>Pełna opieka z priorytetową obsługą.</td>
+                        <td>180 zł</td>
+                    </tr>
+                </tbody>
+            </table>
+            <button id="aftercare-btn" class="aftercare-btn">Rozszerz opiekę</button>
+        </div>
+    </section>
+
+    <div id="aftercare-modal" class="modal">
+        <div class="modal-content">
+            <span id="aftercare-close" class="modal-close">&times;</span>
+            <h3>Rozszerz opiekę</h3>
+            <form id="aftercare-form">
+                <input type="text" placeholder="Twoje imię" required>
+                <input type="email" placeholder="Twój e-mail" required>
+                <button type="submit">Wyślij</button>
+            </form>
+        </div>
+    </div>
+
     <!-- Contact section -->
     <section id="contact" class="contact">
         <div class="container">

--- a/script.js
+++ b/script.js
@@ -36,4 +36,35 @@ document.addEventListener('DOMContentLoaded', () => {
             });
         });
     });
+
+    // Aftercare modal logic
+    const aftercareBtn = document.getElementById('aftercare-btn');
+    const aftercareModal = document.getElementById('aftercare-modal');
+    const aftercareClose = document.getElementById('aftercare-close');
+    const aftercareForm = document.getElementById('aftercare-form');
+
+    if (aftercareBtn && aftercareModal && aftercareClose) {
+        aftercareBtn.addEventListener('click', () => {
+            aftercareModal.classList.add('show');
+        });
+
+        aftercareClose.addEventListener('click', () => {
+            aftercareModal.classList.remove('show');
+        });
+
+        aftercareModal.addEventListener('click', (e) => {
+            if (e.target === aftercareModal) {
+                aftercareModal.classList.remove('show');
+            }
+        });
+    }
+
+    if (aftercareForm) {
+        aftercareForm.addEventListener('submit', (e) => {
+            e.preventDefault();
+            alert('Dziękuję! Wkrótce się skontaktuję.');
+            aftercareForm.reset();
+            aftercareModal.classList.remove('show');
+        });
+    }
 });

--- a/style.css
+++ b/style.css
@@ -231,6 +231,110 @@ body {
     display: none;
 }
 
+/* Aftercare section */
+.aftercare-table {
+    width: 100%;
+    border-collapse: collapse;
+    margin-bottom: 20px;
+}
+
+.aftercare-table th,
+.aftercare-table td {
+    border: 1px solid var(--primary-color);
+    padding: 10px;
+    text-align: left;
+}
+
+.aftercare-table th {
+    background-color: var(--secondary-color);
+    color: var(--primary-color);
+}
+
+.aftercare-btn {
+    padding: 10px 20px;
+    background-color: var(--primary-color);
+    color: #00130d;
+    border: none;
+    border-radius: 4px;
+    font-weight: bold;
+    cursor: pointer;
+    transition: background-color 0.3s;
+}
+
+.aftercare-btn:hover {
+    background-color: #00d173;
+}
+
+/* Modal styles */
+.modal {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: rgba(0, 0, 0, 0.7);
+    display: none;
+    align-items: center;
+    justify-content: center;
+    z-index: 1000;
+}
+
+.modal.show {
+    display: flex;
+}
+
+.modal-content {
+    background: var(--secondary-color);
+    padding: 20px;
+    border-radius: 8px;
+    width: 90%;
+    max-width: 400px;
+    position: relative;
+}
+
+.modal-content h3 {
+    margin-bottom: 15px;
+    color: var(--primary-color);
+}
+
+.modal-close {
+    position: absolute;
+    top: 10px;
+    right: 15px;
+    font-size: 1.5rem;
+    color: var(--primary-color);
+    cursor: pointer;
+}
+
+.modal-content form {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+}
+
+.modal-content input {
+    padding: 10px;
+    border: 1px solid var(--primary-color);
+    background-color: var(--secondary-color);
+    border-radius: 4px;
+    color: var(--text-color);
+}
+
+.modal-content button {
+    padding: 10px;
+    background-color: var(--primary-color);
+    color: #00130d;
+    border: none;
+    border-radius: 4px;
+    font-weight: bold;
+    cursor: pointer;
+    transition: background-color 0.3s;
+}
+
+.modal-content button:hover {
+    background-color: #00d173;
+}
+
 /* Contact section */
 .contact form {
     max-width: 500px;


### PR DESCRIPTION
## Summary
- Add "Opieka po realizacji" section with pricing table and modal CTA.
- Style table, button, and modal overlay for responsive display.
- Implement JavaScript to open and close the aftercare modal and handle form submit.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688ddfc016c0832f8c25747ad372930c