### PR TITLE
Merge hero section padding into main block

### DIFF
--- a/style.css
+++ b/style.css
@@ -37,6 +37,7 @@ a:hover {
     display: flex;
     align-items: center;
     justify-content: center;
+    padding-top: 4rem; /* Account for fixed navbar */
     text-align: center;
     background: linear-gradient(135deg, #0a0a0a 0%, #121212 50%, #0a0a0a 100%);
 }
@@ -151,11 +152,6 @@ a:hover {
     backdrop-filter: blur(5px);
     padding: 0.5rem 1rem;
     z-index: 1000;
-}
-
-/* Add top padding to the hero section to account for the fixed navbar */
-.hero-section {
-    padding-top: 4rem;
 }
 
 .nav ul {


### PR DESCRIPTION
## Summary
- move top padding into main `.hero-section` rule for clearer styling
- remove duplicate `.hero-section` block that existed after nav styles

## Testing
- `npm test` *(fails: ENOENT no such file or directory 'package.json')*


------
https://chatgpt.com/codex/tasks/task_e_68956750e464832f89e655074da16313